### PR TITLE
CRITICAL: filename case fix. Upper case does not build on Linux

### DIFF
--- a/lib/widgets/portrait_mode_mixin.dart
+++ b/lib/widgets/portrait_mode_mixin.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/cupertino.Dart';
-import 'package:flutter/services.Dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/services.dart';
 
 /// Forces portrait-only mode application-wide
 /// Use this Mixin on the main app widget i.e. app.Dart


### PR DESCRIPTION
## This is a critical bug fix

A friend of mine discovered that he cannot build a project with **advance_image_picker** included, since these two files are using uppercase in the filename, as show in diff below.

On a Linux/Chrome system these Flutter SDK files can then not be found when building the project, since they will be using lower case names as downloaded for the build and not upper case .**D**art as shown below, which would be different files.

Yes, on Windows and macOS that do not use case sensitive file systems, the upper case names used in current code works.

This is a good example of why your lovely image picker really needs a linter, as I suggested and proposed here https://github.com/weta-vn/advance_image_picker/issues/15

There is actually a lint rule to detect and avoid this exact issue (https://dart-lang.github.io/linter/lints/file_names.html) and yes it is of course enabled in my suggestion too. 💙 
